### PR TITLE
Allow implementers to implement an optional 'length' method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        maven { url "http://palantir.bintray.com/releases" }
         jcenter()
     }
 

--- a/seek-io/src/main/java/com/palantir/seekio/InMemorySeekableDataInput.java
+++ b/seek-io/src/main/java/com/palantir/seekio/InMemorySeekableDataInput.java
@@ -20,6 +20,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.util.OptionalLong;
 
 public final class InMemorySeekableDataInput implements SeekableDataInput {
 
@@ -41,6 +42,11 @@ public final class InMemorySeekableDataInput implements SeekableDataInput {
             bytes.get(buf, offset, length);
             return length;
         }
+    }
+
+    @Override
+    public OptionalLong length() throws IOException {
+        return OptionalLong.of(bytes.capacity());
     }
 
     @Override

--- a/seek-io/src/main/java/com/palantir/seekio/SeekableInput.java
+++ b/seek-io/src/main/java/com/palantir/seekio/SeekableInput.java
@@ -18,6 +18,7 @@ package com.palantir.seekio;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.OptionalLong;
 
 /**
  * A marker interface for seekable inputs.
@@ -41,4 +42,9 @@ public interface SeekableInput extends Closeable {
      */
     int read(byte[] bytes, int offset, int length) throws IOException;
 
+    /**
+     * Gets the total length of the stream, if efficiently computable.
+     * Assumed to be cheap and fast.
+     */
+    OptionalLong length() throws IOException;
 }


### PR DESCRIPTION
I didn't make this maintain backcompat because I want people to have to think about it when implementing - but can alter if this has been used in more places than I know of internally.

Add a length method; having it available would allow us to kill some async code, a cache, and some perf benchmark pain too.