### PR TITLE
Better method of sizing

### DIFF
--- a/seek-io/src/main/java/com/palantir/seekio/DefaultSizedSeekableInput.java
+++ b/seek-io/src/main/java/com/palantir/seekio/DefaultSizedSeekableInput.java
@@ -18,11 +18,11 @@ package com.palantir.seekio;
 
 import java.io.IOException;
 
-public final class SizingSeekableDataInput implements SizedSeekableDataInput {
+public final class DefaultSizedSeekableInput implements SizedSeekableDataInput {
     private final SeekableDataInput delegate;
     private final long streamLength;
 
-    public SizingSeekableDataInput(SeekableDataInput delegate, long streamLength) {
+    public DefaultSizedSeekableInput(SeekableDataInput delegate, long streamLength) {
         this.delegate = delegate;
         this.streamLength = streamLength;
     }

--- a/seek-io/src/main/java/com/palantir/seekio/InMemorySeekableDataInput.java
+++ b/seek-io/src/main/java/com/palantir/seekio/InMemorySeekableDataInput.java
@@ -44,11 +44,6 @@ public final class InMemorySeekableDataInput implements SeekableDataInput {
     }
 
     @Override
-    public long length() throws IOException {
-        return bytes.capacity();
-    }
-
-    @Override
     public void readFully(byte[] buf) throws IOException {
         try {
             bytes.get(buf);

--- a/seek-io/src/main/java/com/palantir/seekio/SizedSeekableDataInput.java
+++ b/seek-io/src/main/java/com/palantir/seekio/SizedSeekableDataInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,13 @@
 
 package com.palantir.seekio;
 
-import java.io.Closeable;
 import java.io.IOException;
 
-/**
- * A marker interface for seekable inputs.
- * <p>
- * {@link #seek(long)} and {@link #getPos()} are assumed to be both cheap and fast.
- */
-public interface SeekableInput extends Closeable {
+public interface SizedSeekableDataInput extends SeekableDataInput {
 
     /**
-     * Seeks to the given offset in the stream.
+     * Gets the total length of the stream.
+     * Assumed to be cheap and fast.
      */
-    void seek(long offset) throws IOException;
-
-    /**
-     * Gets the current byte offset in the stream.
-     */
-    long getPos() throws IOException;
-
-    /**
-     * @see java.io.InputStream#read(byte[], int, int)
-     */
-    int read(byte[] bytes, int offset, int length) throws IOException;
+    long length() throws IOException;
 }

--- a/seek-io/src/main/java/com/palantir/seekio/SizingSeekableDataInput.java
+++ b/seek-io/src/main/java/com/palantir/seekio/SizingSeekableDataInput.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.seekio;
+
+import java.io.IOException;
+
+public class SizingSeekableDataInput implements SizedSeekableDataInput {
+    private final SeekableDataInput delegate;
+    private final long streamLength;
+
+    public SizingSeekableDataInput(SeekableDataInput delegate, long streamLength) {
+        this.delegate = delegate;
+        this.streamLength = streamLength;
+    }
+
+    @Override
+    public void seek(long offset) throws IOException {
+        delegate.seek(offset);
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return delegate.getPos();
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int length) throws IOException {
+        return delegate.read(bytes, offset, length);
+    }
+
+    @Override
+    public long length() {
+        return streamLength;
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    @Override
+    public byte readByte() throws IOException {
+        return delegate.readByte();
+    }
+
+    @Override
+    public short readShort() throws IOException {
+        return delegate.readShort();
+    }
+
+    @Override
+    public int readInt() throws IOException {
+        return delegate.readInt();
+    }
+
+    @Override
+    public long readLong() throws IOException {
+        return delegate.readLong();
+    }
+
+    @Override
+    public int skipBytes(int numBytes) throws IOException {
+        return delegate.skipBytes(numBytes);
+    }
+
+    @Override
+    public void readFully(byte[] buf) throws IOException {
+        delegate.readFully(buf);
+    }
+
+    @Override
+    public void readFully(byte[] buf, int offset, int length) throws IOException {
+        delegate.readFully(buf, offset, length);
+    }
+
+    @Override
+    public boolean readBoolean() throws IOException {
+        return delegate.readBoolean();
+    }
+
+    @Override
+    public int readUnsignedByte() throws IOException {
+        return delegate.readUnsignedByte();
+    }
+
+    @Override
+    public int readUnsignedShort() throws IOException {
+        return delegate.readUnsignedShort();
+    }
+
+    @Override
+    public char readChar() throws IOException {
+        return delegate.readChar();
+    }
+
+    @Override
+    public float readFloat() throws IOException {
+        return delegate.readFloat();
+    }
+
+    @Override
+    public double readDouble() throws IOException {
+        return delegate.readDouble();
+    }
+
+    @Override
+    public String readLine() throws IOException {
+        return delegate.readLine();
+    }
+
+    @Override
+    public String readUTF() throws IOException {
+        return delegate.readUTF();
+    }
+}

--- a/seek-io/src/main/java/com/palantir/seekio/SizingSeekableDataInput.java
+++ b/seek-io/src/main/java/com/palantir/seekio/SizingSeekableDataInput.java
@@ -18,7 +18,7 @@ package com.palantir.seekio;
 
 import java.io.IOException;
 
-public class SizingSeekableDataInput implements SizedSeekableDataInput {
+public final class SizingSeekableDataInput implements SizedSeekableDataInput {
     private final SeekableDataInput delegate;
     private final long streamLength;
 


### PR DESCRIPTION
In practice, the task to get the size of the input stream is generally
different than the task to get the input stream itself, and may be
accessed through different systems.

Given that getting the length is supposed to be cheap and fast, you
really want to compute it before giving the user their input.

Given that this interface works well as a delegate, you then don't
want to unnecessarily precompute the length at a lower level if it
can be more cheaply computed at a higher level.

This PR adds SizedSeekableDataInput, which adds the length method
to SeekableDataInput.

The lower level implementer can then implement SeekableDataInput,
and at any level we can wrap with SizingSeekableDataInput in order to
provide a length, computing by any means necessary.