### PR TITLE
Add a length() method to InMemorySeekableDataInput

### DIFF
--- a/seek-io/src/main/java/com/palantir/seekio/InMemorySeekableDataInput.java
+++ b/seek-io/src/main/java/com/palantir/seekio/InMemorySeekableDataInput.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
-public final class InMemorySeekableDataInput implements SeekableDataInput {
+public final class InMemorySeekableDataInput implements SizedSeekableDataInput {
 
     private final ByteBuffer bytes;
 
@@ -59,6 +59,11 @@ public final class InMemorySeekableDataInput implements SeekableDataInput {
         } catch (BufferUnderflowException e) {
             throw new EOFException();
         }
+    }
+
+    @Override
+    public long length() {
+        return bytes.capacity();
     }
 
     @Override
@@ -154,5 +159,4 @@ public final class InMemorySeekableDataInput implements SeekableDataInput {
 
     @Override
     public void close() {}
-
 }


### PR DESCRIPTION
Unsure whether we want to keep this as InMemorySeekableDataInput,
or make an InMemorySizedSeekableDataInput and deprecate this one.

Thoughts?