### PR TITLE
Null out the backing byte buffer after close()

### DIFF
--- a/seek-io/src/main/java/com/palantir/seekio/InMemorySeekableDataInput.java
+++ b/seek-io/src/main/java/com/palantir/seekio/InMemorySeekableDataInput.java
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer;
 
 public final class InMemorySeekableDataInput implements SeekableDataInput {
 
-    private final ByteBuffer bytes;
+    private ByteBuffer bytes;
 
     public InMemorySeekableDataInput(byte[] bytes) {
         this.bytes = ByteBuffer.wrap(bytes);
@@ -153,6 +153,8 @@ public final class InMemorySeekableDataInput implements SeekableDataInput {
     }
 
     @Override
-    public void close() {}
+    public void close() {
+        bytes = null;
+    }
 
 }


### PR DESCRIPTION
Make the byte buffer available to be GC'd.